### PR TITLE
Fix #24 per thread throughput

### DIFF
--- a/src/ntttcp.c
+++ b/src/ntttcp.c
@@ -3286,16 +3286,18 @@ DoSendsReceives(
     }
 
     while (num_ios < max_num_ios) {
-        if (tcp_row) {
-            if (start_recording_results && !time0_was_set) {
-                _ftime(&time0);
+        if (start_recording_results && !time0_was_set) {
+            _ftime(&time0);
+            if (tcp_row) {
                 GetEstats(tcp_row, &test_begin_estats);
-                time0_was_set = TRUE;
-            } else if (time0_was_set && !start_recording_results && !time1_was_set) {
-                _ftime(&time1);
-                GetEstats(tcp_row, &test_end_estats);
-                time1_was_set = TRUE;
             }
+            time0_was_set = TRUE;
+        } else if (time0_was_set && !start_recording_results && !time1_was_set) {
+            _ftime(&time1);
+            if (tcp_row) {
+                GetEstats(tcp_row, &test_end_estats);
+            }
+            time1_was_set = TRUE;
         }
 
         if (test_finished) break;
@@ -3729,16 +3731,18 @@ DoAsynchSendsReceives(
     }
 
     while(num_ios < max_num_ios) {
-        if (tcp_row) {
-            if (start_recording_results && !time0_was_set) {
-                _ftime(&time0);
+        if (start_recording_results && !time0_was_set) {
+            _ftime(&time0);
+            if (tcp_row) {
                 GetEstats(tcp_row, &test_begin_estats);
-                time0_was_set = TRUE;
-            } else if (time0_was_set && !start_recording_results && !time1_was_set) {
-                _ftime(&time1);
-                GetEstats(tcp_row, &test_end_estats);
-                time1_was_set = TRUE;
             }
+            time0_was_set = TRUE;
+        } else if (time0_was_set && !start_recording_results && !time1_was_set) {
+            _ftime(&time1);
+            if (tcp_row) {
+                GetEstats(tcp_row, &test_end_estats);
+            }
+            time1_was_set = TRUE;
         }
 
         if (test_finished) {

--- a/src/ntttcp.c
+++ b/src/ntttcp.c
@@ -856,7 +856,7 @@ exit:
 _Success_(return == TRUE)
 BOOL
 GetEstats(
-    __in const PVOID tcp_row,
+    __in_opt const PVOID tcp_row,
     __out PESTATS_DATA estats_data
     )
 {

--- a/src/ntttcp.c
+++ b/src/ntttcp.c
@@ -3453,7 +3453,7 @@ DoSendsReceives(
             time0_was_set && time1_was_set ?
                 MS2S * (time1.time - time0.time) + (time1.millitm - time0.millitm) :
                 0;
-        if (flags.get_estats) {
+        if (flags.get_estats && test_begin_estats.is_valid_data && test_end_estats.is_valid_data) {
             ASSERT ( NULL != local_perf_info->test_begin_estats);
             ASSERT ( NULL != local_perf_info->test_end_estats);
 
@@ -3880,7 +3880,7 @@ DoAsynchSendsReceives(
             time0_was_set && time1_was_set ?
                 MS2S * (time1.time - time0.time) + (time1.millitm - time0.millitm) :
                 0;
-        if (flags.get_estats) {
+        if (flags.get_estats && test_begin_estats.is_valid_data && test_end_estats.is_valid_data) {
             ASSERT ( NULL != local_perf_info->test_begin_estats);
             ASSERT ( NULL != local_perf_info->test_end_estats);
 


### PR DESCRIPTION
## Summary

Fixes per-thread throughput is always 0.00 with ntttcp version 5.40.

In v5.40, worker start/end timing was tied to `tcp_row`, which is only
initialized when TCP EStats are enabled. As a result, normal runs without
`-es` left `worker_time` as zero, causing per-thread `Time(s)` and
`Throughput(KB/s)` to print as `0.000` even though total throughput was
reported correctly.

This change records worker timing independently from EStats collection while
keeping EStats calls guarded by `tcp_row`.

Fixes #24 .

## Validation

- Built locally in Visual Studio using the `ntttcp.sln` file.
- Manually ran the reported sender/receiver command pattern.
- Reproduced the issue without `-es`: per-thread `Time(s)` and
  `Throughput(KB/s)` were `0.000` while total throughput was nonzero.
- Confirmed the suspected cause by running with `-es`: per-thread timing was
  recorded because `tcp_row` was initialized.
- Confirmed the fix by running without `-es`: per-thread `Time(s)` and
  `Throughput(KB/s)` are now nonzero.
- Confirmed the `-es` path still reports nonzero per-thread `Time(s)` and
  `Throughput(KB/s)` after the fix.

## Screenshots

### Before: without `-es`

Per-thread `Time(s)` and `Throughput(KB/s)` were reported as `0.000`, while
total throughput was still nonzero.

<img width="1600" height="1145" alt="recv_without_es" src="https://github.com/user-attachments/assets/52c151a9-dc46-41de-8256-48107adb1d03" />
<img width="1158" height="745" alt="sender_without_es" src="https://github.com/user-attachments/assets/2fd72eec-b187-4bc5-9a1f-8178895299d1" />

### Confirmation: with `-es`

Running the same command pattern with `-es` recorded nonzero per-thread time,
confirming that timing was incorrectly coupled to `tcp_row`.

<img width="1600" height="1172" alt="recv_with_es" src="https://github.com/user-attachments/assets/7d5a9b72-404a-4d2b-82b8-9237719f0656" />
<img width="1221" height="747" alt="sender_with_es" src="https://github.com/user-attachments/assets/cc58e6c9-9d4e-443e-a01c-b89e7332f942" />

### After fix: without `-es`

After the fix, the same command pattern works without `-es`: per-thread
`Time(s)` and `Throughput(KB/s)` are nonzero.

<img width="1600" height="1211" alt="recv_after_fix" src="https://github.com/user-attachments/assets/55c5befe-5a38-4d73-9c1d-a751b7ca8fa4" />
<img width="1267" height="746" alt="sender_after_fix" src="https://github.com/user-attachments/assets/a25b1d51-49ea-4981-afc4-58ce78a9b8a0" />

### After fix: with `-es`

The `-es` path still records nonzero per-thread `Time(s)` and
`Throughput(KB/s)` after the timing change.

<img width="1600" height="1225" alt="recv_after_fix_with_es" src="https://github.com/user-attachments/assets/db29ca56-50ba-4a95-a231-0e5ae161faec" />
<img width="1326" height="787" alt="sender_after_fix_with_es" src="https://github.com/user-attachments/assets/15d6540e-30f5-45fe-99af-cda1a34fcb28" />


## Follow-up for [a0a7d6e](https://github.com/microsoft/ntttcp/pull/31/commits/a0a7d6e956e38e0cec85f75466f802521e703443)

This addresses the Copilot code review:

- Added a guard requiring both begin and end EStats snapshots to be valid
  before marking EStats as available.
- Validated the EStats initialization failure path with `-es` using XML output:
  before the fix, zero-initialized EStats were emitted; after the fix,
  per-thread `Time(s)` and `Throughput(KB/s)` remain nonzero and EStats are
  not emitted.
- Confirmed normal `-es` runs after the fix still emit valid EStats data.
- EStats are marked available only when both the begin and end EStats snapshots were successfully collected; worker timing is independent of EStats collection.