### PR TITLE
Fix per-thread throughput when EStats are disabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
       uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
     - name: Nuget Restore
       run: nuget.exe restore ntttcp.sln
+    - name: Per-thread throughput regression test
+      shell: pwsh
+      run: ./tests/test_per_thread_throughput.ps1
     - name: Build
       run: msbuild ntttcp.sln /p:Configuration=Release /p:Platform=${{ matrix.platform }}
     - name: Upload

--- a/src/ntttcp.c
+++ b/src/ntttcp.c
@@ -3286,16 +3286,18 @@ DoSendsReceives(
     }
 
     while (num_ios < max_num_ios) {
-        if (tcp_row) {
-            if (start_recording_results && !time0_was_set) {
-                _ftime(&time0);
+        if (start_recording_results && !time0_was_set) {
+            _ftime(&time0);
+            if (tcp_row) {
                 GetEstats(tcp_row, &test_begin_estats);
-                time0_was_set = TRUE;
-            } else if (time0_was_set && !start_recording_results && !time1_was_set) {
-                _ftime(&time1);
-                GetEstats(tcp_row, &test_end_estats);
-                time1_was_set = TRUE;
             }
+            time0_was_set = TRUE;
+        } else if (time0_was_set && !start_recording_results && !time1_was_set) {
+            _ftime(&time1);
+            if (tcp_row) {
+                GetEstats(tcp_row, &test_end_estats);
+            }
+            time1_was_set = TRUE;
         }
 
         if (test_finished) break;
@@ -3421,7 +3423,9 @@ DoSendsReceives(
         }
 
         _ftime(&time1);
-        GetEstats(tcp_row, &test_end_estats);
+        if (tcp_row) {
+            GetEstats(tcp_row, &test_end_estats);
+        }
         time1_was_set = TRUE;
     }
 
@@ -3451,7 +3455,7 @@ DoSendsReceives(
             time0_was_set && time1_was_set ?
                 MS2S * (time1.time - time0.time) + (time1.millitm - time0.millitm) :
                 0;
-        if (flags.get_estats) {
+        if (flags.get_estats && tcp_row) {
             ASSERT ( NULL != local_perf_info->test_begin_estats);
             ASSERT ( NULL != local_perf_info->test_end_estats);
 
@@ -3729,16 +3733,18 @@ DoAsynchSendsReceives(
     }
 
     while(num_ios < max_num_ios) {
-        if (tcp_row) {
-            if (start_recording_results && !time0_was_set) {
-                _ftime(&time0);
+        if (start_recording_results && !time0_was_set) {
+            _ftime(&time0);
+            if (tcp_row) {
                 GetEstats(tcp_row, &test_begin_estats);
-                time0_was_set = TRUE;
-            } else if (time0_was_set && !start_recording_results && !time1_was_set) {
-                _ftime(&time1);
-                GetEstats(tcp_row, &test_end_estats);
-                time1_was_set = TRUE;
             }
+            time0_was_set = TRUE;
+        } else if (time0_was_set && !start_recording_results && !time1_was_set) {
+            _ftime(&time1);
+            if (tcp_row) {
+                GetEstats(tcp_row, &test_end_estats);
+            }
+            time1_was_set = TRUE;
         }
 
         if (test_finished) {
@@ -3840,7 +3846,9 @@ DoAsynchSendsReceives(
         }
 
         _ftime(&time1);
-        GetEstats(tcp_row, &test_end_estats);
+        if (tcp_row) {
+            GetEstats(tcp_row, &test_end_estats);
+        }
         time1_was_set = TRUE;
     }
 
@@ -3876,7 +3884,7 @@ DoAsynchSendsReceives(
             time0_was_set && time1_was_set ?
                 MS2S * (time1.time - time0.time) + (time1.millitm - time0.millitm) :
                 0;
-        if (flags.get_estats) {
+        if (flags.get_estats && tcp_row) {
             ASSERT ( NULL != local_perf_info->test_begin_estats);
             ASSERT ( NULL != local_perf_info->test_end_estats);
 

--- a/tests/test_per_thread_throughput.ps1
+++ b/tests/test_per_thread_throughput.ps1
@@ -1,0 +1,66 @@
+param(
+    [string]$SourcePath = (Join-Path $PSScriptRoot '..\src\ntttcp.c')
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-True {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Get-FunctionBody {
+    param(
+        [string]$Source,
+        [string]$StartMarker,
+        [string]$EndMarker
+    )
+
+    $start = $Source.IndexOf($StartMarker, [StringComparison]::Ordinal)
+    Assert-True ($start -ge 0) "Could not find function marker '$StartMarker'."
+
+    $end = $Source.IndexOf($EndMarker, $start, [StringComparison]::Ordinal)
+    Assert-True ($end -gt $start) "Could not find end marker '$EndMarker'."
+
+    return $Source.Substring($start, $end - $start)
+}
+
+$source = Get-Content -LiteralPath $SourcePath -Raw
+$functions = @(
+    @{
+        Name = 'synchronous worker'
+        Body = Get-FunctionBody $source 'DoSendsReceives(' 'PostAsynchBuffer('
+    },
+    @{
+        Name = 'asynchronous worker'
+        Body = Get-FunctionBody $source 'DoAsynchSendsReceives(' 'AllocateAsynchBuffers('
+    }
+)
+
+foreach ($function in $functions) {
+    $body = $function.Body
+    $name = $function.Name
+
+    Assert-True (
+        $body -notmatch '(?s)if\s*\(\s*tcp_row\s*\)\s*\{\s*if\s*\(\s*start_recording_results'
+    ) "$name still gates worker timing on tcp_row."
+
+    Assert-True (
+        $body -match '(?s)if\s*\(\s*start_recording_results\s*&&\s*!time0_was_set\s*\)\s*\{.*?_ftime\(\&time0\);.*?if\s*\(\s*tcp_row\s*\)\s*\{\s*GetEstats\(tcp_row,\s*\&test_begin_estats\);.*?time0_was_set\s*=\s*TRUE;'
+    ) "$name does not record the start time independently of EStats."
+
+    Assert-True (
+        $body -match '(?s)else\s+if\s*\(\s*time0_was_set\s*&&\s*!start_recording_results\s*&&\s*!time1_was_set\s*\)\s*\{\s*_ftime\(\&time1\);.*?if\s*\(\s*tcp_row\s*\)\s*\{\s*GetEstats\(tcp_row,\s*\&test_end_estats\);.*?time1_was_set\s*=\s*TRUE;'
+    ) "$name does not record the end time independently of EStats."
+
+    Assert-True ($body.Contains('if (flags.get_estats && tcp_row)')) "$name can mark unavailable EStats as available."
+    Assert-True ($body.Contains('local_perf_info->bytes_transferred +=')) "$name no longer records per-thread bytes."
+}
+
+Write-Output 'Per-thread throughput regression checks passed.'


### PR DESCRIPTION
Fixes #24

## Cause

In v5.40, worker start/end timestamps were captured only inside the `tcp_row` block. `tcp_row` is created only for successful TCP EStats setup, so normal runs without `-es` left per-thread worker time at zero even though per-thread byte counters and totals were populated.

## Change

- Capture worker start/end timestamps independently of optional EStats collection in both synchronous and asynchronous worker paths.
- Keep EStats calls and availability gated by a valid `tcp_row`.
- Leave per-thread byte accounting, totals, and throughput measurement formulas unchanged.

## Validation

- Added `tests/test_per_thread_throughput.ps1`, a dependency-free regression guard for both worker paths, and wired it into the Windows build workflow.
- Regression checks pass locally.
- Built Release x64 locally with the available Visual Studio toolchain (using `UndockedSourceLink=false`, `UndockedUseDriverToolset=false`, and `SpectreMitigation=false` because those local components are unavailable).
- Ran rebuilt v5.40 sender/receiver loopback tests without `-es` in synchronous and asynchronous modes; both reported non-zero per-thread time/throughput and non-zero totals.

Related upstream work exists in #31; this change keeps the fix scoped to the issue and preserves existing EStats behavior.